### PR TITLE
对于指针的处理

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
                 "request": "launch",
                 "preLaunchTask": "makeCompile",
                 "program": "${workspaceRoot}/compile/lscc",
-                "args": ["${workspaceRoot}/test/baseTest.c"],
+                "args": ["${workspaceRoot}/test/testPointer.c"],
                 "stopAtEntry": false,
                 "cwd": "${workspaceRoot}",
                 "environment": [],

--- a/compile/GenIR.cpp
+++ b/compile/GenIR.cpp
@@ -254,7 +254,7 @@ Var* GenIR::genAssign(Var* val)
 Var* GenIR::genCopy(Var* val)
 {
     Var* tmp = new Var(symtab.getScopePath(),val);
-
+    symtab.addVar(tmp);     // 任何创建的变量都需要保存到变量表中
     if(val->isRef()){
         // 如果是引用类型, 需要先取出真实值,然后再复制
         val = genAssign(val);

--- a/compile/GenIR.h
+++ b/compile/GenIR.h
@@ -53,6 +53,7 @@ private:
     Var* genMinus(Var* val); 
 
     Var* genAssign(Var* val);
+    Var* genCopy(Var* val);
     Var* genAssign(Var* lval,Var* rval);
 
     Var* genOr(Var* lval,Var* rval);

--- a/compile/Parser.cpp
+++ b/compile/Parser.cpp
@@ -84,9 +84,6 @@ Symbol Parser::type()
     }
 }
 
-// <def>     -> <ID> <idtail>
-// <def>     -> * <ID> <idtail>
-
 // <def>   ->  <ID><idtail>
 // <mulss> ->  * <mulss>
 // <mulss> -> e
@@ -225,8 +222,9 @@ void Parser::para(std::vector<Var*>& para)
     
 }
 
-// <paradata> -> * <ID>
-// <paradata> -> <ID> <paradatatail>
+// <paradata> -> <mulss> <ID> <paradatatail>
+// <mulss> ->  * <mulss>
+// <mulss> -> e
 Var* Parser::paradata(Symbol s)
 {
     string name;

--- a/compile/Parser.cpp
+++ b/compile/Parser.cpp
@@ -230,33 +230,27 @@ void Parser::para(std::vector<Var*>& para)
 Var* Parser::paradata(Symbol s)
 {
     string name;
-    if(match(MUL)){
-        if(firstIs(IDENT)){
-            name = ((ID*)look) -> name;
-            move();
-            return new Var(symtab.getScopePath(),false,s,true,name,nullptr);
-        }
-        else{
-            recovery(firstIs(COMMA)_OR_(RPAREN), ID_LOST,ID_WRONG);
-        }
+    int ptrLevel = 0;
+    while(match(MUL)){
+        ptrLevel++;
+    }
+
+    if(firstIs(IDENT)){
+        name = ((ID*)look) -> name;
+        move();
+        return paradatatail(s,name,ptrLevel);
     }
     else{
-        if(firstIs(IDENT)){
-            name = ((ID*)look) -> name;
-            move();
-            return paradatatail(s,name);
-        }
-        else{
-            recovery(firstIs(COMMA)_OR_(RPAREN)_OR_(LBRACK), ID_LOST,ID_WRONG);
-        }
+        recovery(firstIs(COMMA)_OR_(RPAREN)_OR_(LBRACK), ID_LOST,ID_WRONG);
     }
+
     // 无论何种错误,最后都需要返回一个Var*
-    return new Var(symtab.getScopePath(),false,s,false,name,nullptr);
+    return new Var(symtab.getScopePath(),false,s,false,name,nullptr);    
 }
 
 // <paradatatail> -> [ <num> ]
 // <paradatatail> -> e
-Var* Parser::paradatatail(Symbol s,string name)
+Var* Parser::paradatatail(Symbol s,string name,int ptrLevel)
 {
     if(match(LBRACK)){
         // 函数参数列表中的数组可以没有指定长度
@@ -271,10 +265,10 @@ Var* Parser::paradatatail(Symbol s,string name)
             recovery(firstIs(COMMA),RBRACK_LOST,RBRACK_WRONG);
         }
 
-        return new Var(symtab.getScopePath(),false,s,false,name,len);
+        return new Var(symtab.getScopePath(),false,s,ptrLevel,name,len);
     }
     else{
-        return new Var(symtab.getScopePath(),false,s,false,name,nullptr);
+        return new Var(symtab.getScopePath(),false,s,ptrLevel,name,nullptr);
     }
 }
 

--- a/compile/Parser.h
+++ b/compile/Parser.h
@@ -28,9 +28,9 @@ private:
     // 定义变量有关的函数
     // 上层函数获得信息后,作为参数传递给下面的语句,下面的函数,实际创建变量并返回
     void def(bool isExtern,Symbol s);
-    void  idtail(bool isExtern,Symbol s,bool isPtr,std::string name);
-    Var* defvar(bool isExtern,Symbol s,bool isPtr,std::string name);
-    Var* init(bool isExtern,Symbol s,bool isPtr,std::string name);
+    void  idtail(bool isExtern,Symbol s,int ptrLevel,std::string name);
+    Var* defvar(bool isExtern,Symbol s,int ptrLevel,std::string name);
+    Var* init(bool isExtern,Symbol s,int ptrLevel,std::string name);
     void deflist(bool isExtern,Symbol s);
 
     // 函数

--- a/compile/Parser.h
+++ b/compile/Parser.h
@@ -36,7 +36,7 @@ private:
     // 函数
     void para(std::vector<Var*>& para);
     Var* paradata(Symbol s);
-    Var* paradatatail(Symbol s,std::string name);
+    Var* paradatatail(Symbol s,string name,int ptrLevel);
     void paralist(std::vector<Var*>& para);
     void funtail(Fun* fun);
     void block();

--- a/compile/SymTab.cpp
+++ b/compile/SymTab.cpp
@@ -584,6 +584,16 @@ InterInst* Fun::getReturnPoint()
     return returnPoint;
 }
 
+void Fun::setPtrLevel(int level)
+{
+    this->ptrLevel = level;
+}
+
+int Fun::getPtrLevel()
+{
+    return ptrLevel;
+}
+
 void Fun::toX86(FILE* file)
 {
     auto v = intercode.getCode();

--- a/compile/SymTab.cpp
+++ b/compile/SymTab.cpp
@@ -212,6 +212,11 @@ Var* Var::getPointer()
     return ptr;
 }
 
+int Var::getPtrLevel()
+{
+    return ptrLevel;
+}
+
 string Var::getPtrVal()
 {
     return ptrVal;
@@ -349,6 +354,11 @@ void Var::setPoint(Var* ptr)
 void Var::setOffset(int offset)
 {
     this->offset = offset;
+}
+
+void Var::setPtrLevel(int level)
+{
+    this->ptrLevel = level;
 }
 
 void Var::value()

--- a/compile/SymTab.h
+++ b/compile/SymTab.h
@@ -124,6 +124,9 @@ public:
     void setReturnPoint(InterInst* inst);   // 设置函数返回点
     InterInst* getReturnPoint();            // 获得函数返回点
 
+    void setPtrLevel(int level);
+    int getPtrLevel();
+
     bool getExtern();
     void setExtern(bool isExtern);
     Symbol getType();
@@ -138,6 +141,7 @@ public:
 private:
     bool externed;                  // 是否有extern声明
     Symbol type;                    // 返回类型
+    int ptrLevel;                   // 指针等级
     std::string name;               // 函数名
     std::vector<Var*> paraVar;      // 参数列表
 

--- a/compile/SymTab.h
+++ b/compile/SymTab.h
@@ -17,13 +17,13 @@ public:
     Var(Token* literal);
 
     // 初始化一个数组
-    Var(std::vector<int> scopePath,bool isExtern,Symbol s,bool isPtr,std::string name,int len);
+    Var(std::vector<int> scopePath,bool isExtern,Symbol s,int ptrLevel,std::string name,int len);
     
     // 初始化普通的变量,指针
-    Var(std::vector<int> scopePath,bool isExtern,Symbol s,bool isPtr,std::string name,Var* init);
+    Var(std::vector<int> scopePath,bool isExtern,Symbol s,int ptrLevel,std::string name,Var* init);
 
     // 临时变量
-    Var(std::vector<int> scopePath,Symbol s,bool isPtr);
+    Var(std::vector<int> scopePath,Symbol s,int ptrLevel);
 
     // 变量拷贝
     Var(std::vector<int> scopePath, Var* val);
@@ -62,7 +62,7 @@ public:
     void baseInit();                            // 默认初始化
     void setExterned(bool isExtern);
     void setType(Symbol s);
-    void setPtr(bool isPtr);
+    void setPtr(int ptrLevel);
     void setName(std::string name);
     void setArray(int len);
     void setLeft(bool isLeft);
@@ -81,7 +81,7 @@ private:
     bool externed;                  // 是否有extern声明
     Symbol type;                    // 变量类型
     std::string name;               // 变量名
-    bool isPtr;                     // 是否是指针
+    //bool isPtr;                     // 是否是指针
     bool isArray;                   // 是否是数组
     int arraySize;                  // 数组长度
     bool isLeft;                    // 是否是左值
@@ -109,7 +109,7 @@ private:
 class Fun
 {
 public:
-    Fun(bool isExtern,Symbol type,std::string name,std::vector<Var*> para);
+    Fun(bool isExtern,Symbol type,int ptrLevel,std::string name,std::vector<Var*> para);
 
     void enterScope();              // 进入一个新的作用域
     void leaveScope();              // 退出作用域并计算栈帧大小

--- a/compile/SymTab.h
+++ b/compile/SymTab.h
@@ -40,6 +40,7 @@ public:
     int getOffset();
     Var* getStep();         // 获得相应的变量长度,并返回一个表示该长度的特殊整数变量
     Var* getPointer();      // 获得当前变量对应的指针
+    int getPtrLevel();      // 获得指针等级
     string getPtrVal();     // 获得初始值变量
     string getStrVal();     // 获得初始字符串的值
     int getVal();
@@ -67,6 +68,7 @@ public:
     void setLeft(bool isLeft);
     void setPoint(Var* ptr);
     void setOffset(int offset);
+    void setPtrLevel(int level);
 
     void value();
     void printSelf();
@@ -96,6 +98,7 @@ private:
     
     std::string ptrVal;             // 字符指针初始值
     Var* ptr;                       // 变量的指针变量
+    int ptrLevel;                   // 指针等级,例如int**等级为2
 
 
     int size;                       // 变量大小

--- a/compile/main.cpp
+++ b/compile/main.cpp
@@ -57,6 +57,9 @@ int main(int argc,char* argv[])
     tab.toX86(fpAsm);
     fclose(fpAsm);
 
+    tab.printValTab();
+    tab.printFunTab();
+    tab.printStrTab();
 
     if(err.getErrorNum() > 0){
         printf("\n编译完成!\n");

--- a/docs/compile/GrammaticalAnalysis.md
+++ b/docs/compile/GrammaticalAnalysis.md
@@ -29,12 +29,14 @@ int g(){ }
 #### 变量定义与声明的识别
 对于`<def>` 部分,首先分析变量的定义和声明,在上面的产生式识别了类型声明以后,还可以分成两类
 1. 以标识符开始的普通变量
-2. 以`*`开始的指针
+2. 以任意数量`*`开始的指针
 
 上述两类有可以声明对应的数组类型,因此有如下的产生式
 ```
+<def> -> <mulss> <def>
+<mulss> -> * <mulss>
+<mulss> -> e
 <def> -> <ID><defvar>
-<def> -> * <ID><defvar>
 
 <defvar> -> [ <NUM> ]
 <defvar> -> <init>
@@ -93,8 +95,9 @@ int g(){ }
 <para> -> <type><paradata><paralist>
 <para> -> e
 
-<paradata> -> * <ID>
-<paradata> -> <ID> <paradatatail>
+<paradata> -> <mulss> <ID> <paradatatail>
+<mulss> ->  * <mulss>
+<mulss> -> e
 
 <paradatatail> -> [ <num> ]
 <paradatatail> -> e

--- a/stdlib/start.s
+++ b/stdlib/start.s
@@ -2,11 +2,6 @@ section .data
 section .text
 global @start
 @start:
-    pop esi
-    mov ecx,esp
-    and esp,0xfffffff0
-    push ecx
-    push esi
     call main
     mov eax,1
     mov ebx,0

--- a/test/testPointer.c
+++ b/test/testPointer.c
@@ -1,0 +1,39 @@
+
+int f(){
+    char c;
+    char* pc;
+    char** ppc;
+
+    c = 'c';
+    pc = &c;
+    ppc = &pc;
+
+    pc = *ppc;
+
+    c = *pc;
+    c = **ppc;
+
+    char d;
+    *pc = d;
+    **ppc = d;
+}
+
+
+int g() {
+    char* arr[5];
+    char* pc;
+    arr[0] = pc;
+    arr[1] = *(&pc);
+
+
+    char* pc2;
+    pc2 = arr[0];
+
+    *(arr+2) = pc2;
+}
+
+
+int main(int argc){
+    f();
+    g();
+}

--- a/test/testPointer.c
+++ b/test/testPointer.c
@@ -33,7 +33,8 @@ int g() {
 }
 
 
-int main(int argc){
+int main(int argc, char* argv[]){
+    char* name = argv[0];
     f();
     g();
 }

--- a/test/useArg.c
+++ b/test/useArg.c
@@ -1,6 +1,16 @@
 #include <lscio.h>
 
-int main(int argc, char* argv){
-	lscPrintInt(argc);
+int main(int argc, char* argv[]){
+	lscPrintStr("The Number of Args is ");
+	lscPrintInt(argc); lscPrintStr("\n");
+
+	lscPrintStr("The Args are:\n");
+	int i=0;
+	while(i<argc){
+		lscPrintStr(argv[i]);
+		lscPrintStr("\n");
+		i++;
+	}
+
 	return 0;
 }


### PR DESCRIPTION
修复 #4 

由于之前的设计中并没有考虑多重指针, 且函数返回值也不支持指针, 因此对于此问题有很多需要修改的地方, 大致可以分为如下的几个部分

语法层面
---------------
1. 修改递归下降的表达式
将原有的`<def>`和`<paradata>`进行修改,修改如下
```
<def> -> <mulss> <def>
<mulss> -> * <mulss>
<mulss> -> e

<paradata> -> <mulss> <ID> <paradatatail>
<mulss> ->  * <mulss>
<mulss> -> e
```

由于采用了语法制导翻译, 因此从`<def>`对应的函数开始,直到最后生成变量的函数位置, 所有的函数接口都需要进行一定的调整



代码生成
------------------

1. 首先对于保存变量信息的类Var和保存函数信息的类Fun需要添加表示指针层次的字段ptrLevel
2. 对于Var的构造函数,全部需要进行相关的调整
3. 在递归下降过程中, 逐一的传递参数




类型检查
------------
关于类型检查, 除了检查基本类型意外, 还需要检查指针等级是否匹配




数组的处理
---------------------

由于存在高阶的指针, 因此数组与指针不再是等价的. 但是 数组仍然可以视为指针, 即
`char* arr[]` 仍然可以视为与`char **`等价

为了简化处理, 可以在拷贝变量的时候, 将指针等级置为原等价+是否为数组, 并且将拷贝变量的是否为数组字段置为否



初始化字符串的处理
---------------------

在原有体系内, char*变量可以被字符串常量初始化, 在修改以后,可以通过判断ptrLevel是否为1来继续使用此特性



取地址和取内容操作
---------------------
在原有的体系中, 执行`*p`操作时, 并不生成任何代码, 而只是产生一个变量t, 并且标记t是通过`*p`得到的(即所谓的引用变量). 当需要赋值时,分为两种情况进行

1. `*p`做右值
    - 此时临时的插入一条取内容指令,获得*p的实际值, 再参与后续运算
2. `*p`做左值
    - 此时`*p`原有值并不重要, 直接使用SET指令即可覆盖将指定值写入`*p`


加入高阶指针后, 上述问题复杂度增加, 但基本逻辑不变, 进行`*p`操作时依然只产生一个变量t而不产生代码, 当变量t需要被赋值时,分为两种情况进行
1. t做右值
    - 此时t可能是某个变量经过若干此*操作得到的, 因此通过检查其标记, 不断的回溯其原始变量并产生若干取内容指令
2. t作左值
    - 同右值一样,通过t生成若干此取地址指令, 最后一步使用set指令


### 代码举例
#### 右值
```c
x1 = *x;
t = *x1;

y = t;
```
会依次生成如下代码
```
OP_GET x1 x
OP_GET t x
OP_AS y t
```

#### 左值
```c
x1 = *x;
t = *x1;

t = 5;
```

```
OP_GET x1 x
OP_GET t x1
OP_SET x1 5   // 等价于 *x1 = 5
```
注意: 
1. 这里必须先计算x1的实际值, 之后才能通过x1写入数据
2. `OP_GET t x1`是不需要的, 后续可以通过代码优化去除


指针操作计算
--------------------------

对于原来的指针计算,例如
``` c
char* p
p++
```
就等价与p的地址加上sizeof(char).

现在加入了高阶指针, 因此对于指针的指针运算需要重新编写相关代码, 由于所有的指针都是4字节, 因此对于高阶指针, 不需要区分类型,全部以4为单位递增即可.